### PR TITLE
It looks like there's a potential resource leak in `ProxyConnectionHa…

### DIFF
--- a/core/src/main/kotlin/com/github/l34130/netty/dbgw/core/ProxyConnectionHandler.kt
+++ b/core/src/main/kotlin/com/github/l34130/netty/dbgw/core/ProxyConnectionHandler.kt
@@ -51,7 +51,9 @@ class ProxyConnectionHandler(
         backendFuture.addListener { future ->
             if (!future.isSuccess) {
                 logger.error(future.cause()) { "Failed to connect to backend: ${config.upstreamHost}:${config.upstreamPort}" }
-                backend.close()
+                if (backend != null && backend.isActive) {
+                    backend.close()
+                }
                 frontend.closeOnFlush()
                 return@addListener
             }


### PR DESCRIPTION
…ndler`. If the backend connection fails, the backend channel wasn't being closed. I'll fix this by making sure the backend channel is closed if the connection isn't successful.